### PR TITLE
Chat Message Clipping Fix

### DIFF
--- a/EXPERTconnect/EXPERTconnect/Core/Networking/ECSStompClient.m
+++ b/EXPERTconnect/EXPERTconnect/Core/Networking/ECSStompClient.m
@@ -120,8 +120,6 @@ int         _clientHeartbeatsMissed;
     self.webSocket = [[ECSWebSocket alloc] initWithURL:url];
     self.webSocket.delegate = self;
     [self.webSocket open];
-    
-    NSLog(@"Self = %@", self);
 }
 
 - (void)reconnect
@@ -524,7 +522,6 @@ int         _clientHeartbeatsMissed;
     else if (self.webSocket.readyState == ECS_OPEN && self.connected && self.heartbeatTimer != nil)
     {
         _clientHeartbeatsMissed++;
-        NSLog(@"Self = %@", self);
         ECSLogVerbose(@"doStompHeartbeat: Connection good. Sending. (Pinging again in %d)", _clientHeartbeatInterval);
         NSData *pingData = [[NSData alloc] initWithBytes:(unsigned char[]){0x0A} length:1];
         [self.webSocket sendPing:pingData];

--- a/EXPERTconnect/EXPERTconnect/UI/Common/ECSDynamicLabel.m
+++ b/EXPERTconnect/EXPERTconnect/UI/Common/ECSDynamicLabel.m
@@ -94,4 +94,9 @@ static CGFloat defaultFontIndex;
 {
     self.font = self.baseFont;
 }
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    self.preferredMaxLayoutWidth = self.bounds.size.width;
+    [super layoutSubviews];
+}
 @end


### PR DESCRIPTION
This corrects the issue where chat messages could be clipped off if the
font size was large or iOS accessibility font scaling options were set
to large.
