### PR TITLE
overrideLocale & deprecated getDetailsForSkill

### DIFF
--- a/EXPERTconnect/EXPERTconnect/Core/Networking/ECSStompCallbackClient.m
+++ b/EXPERTconnect/EXPERTconnect/Core/Networking/ECSStompCallbackClient.m
@@ -80,6 +80,8 @@ static NSString * const kECSSendQuestionMessage = @"SendQuestionCommand";
         self.agentInteractionCount = 0;
         
         ECSUserManager *userManager = [[ECSInjector defaultInjector] objectForClass:[ECSUserManager class]];
+        
+        //TODO: This needs userID from somewhere...
         self.fromUsername = userManager.userDisplayName.length ? userManager.userDisplayName : @"Mobile User";
         
     }

--- a/EXPERTconnect/EXPERTconnect/Core/Networking/ECSStompChatClient.m
+++ b/EXPERTconnect/EXPERTconnect/Core/Networking/ECSStompChatClient.m
@@ -90,6 +90,8 @@ static NSString * const kECSChannelTimeoutWarning = @"ChannelTimeoutWarning";
         self.agentInteractionCount = 0;
         
         ECSUserManager *userManager = [[ECSInjector defaultInjector] objectForClass:[ECSUserManager class]];
+        
+        //TODO: This needs userID from somewhere...
         self.fromUsername = userManager.userDisplayName.length ? userManager.userDisplayName : @"Mobile User";
 
     }
@@ -144,7 +146,8 @@ static NSString * const kECSChannelTimeoutWarning = @"ChannelTimeoutWarning";
     
     ECSUserManager *userManager = [[ECSInjector defaultInjector] objectForClass:[ECSUserManager class]];
     ECSChatActionType *chatAction = (ECSChatActionType*)self.actionType;
-
+    ECSURLSessionManager *urlSession = [[ECSInjector defaultInjector] objectForClass:[ECSURLSessionManager class]];
+    
     if (chatAction) {
         if ((chatAction.agentId && chatAction.agentId.length > 0) &&
             (chatAction.agentSkill.length <= 0))
@@ -169,9 +172,15 @@ static NSString * const kECSChannelTimeoutWarning = @"ChannelTimeoutWarning";
         //configuration.features = @{ @"cafexmode": videoChatAction.cafexmode, @"cafextarget": videoChatAction.cafextarget };
     }
     
-    NSString *languageLocale = [NSString stringWithFormat:@"%@_%@",
-                                [[NSLocale preferredLanguages] objectAtIndex:0],
-                                [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode]];
+    NSString *language = [[NSLocale preferredLanguages] objectAtIndex:0];
+    NSString *locale = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
+    NSString *languageLocale = [NSString stringWithFormat:@"%@_%@", language, locale];
+    
+    // Overwrite the device locale if the host app desires to do so.
+    if(urlSession.localLocale)
+    {
+        languageLocale = urlSession.localLocale;
+    }
     featuresDic[@"x-ia-locale"] = languageLocale;
     
     configuration.features = featuresDic; 
@@ -192,7 +201,7 @@ static NSString * const kECSChannelTimeoutWarning = @"ChannelTimeoutWarning";
     NSString *url = nil;
     
     __weak typeof(self) weakSelf = self;
-    ECSURLSessionManager *urlSession = [[ECSInjector defaultInjector] objectForClass:[ECSURLSessionManager class]];
+    
     
     url = self.currentConversation.channelLink;
 

--- a/EXPERTconnect/EXPERTconnect/EXPERTconnect.h
+++ b/EXPERTconnect/EXPERTconnect/EXPERTconnect.h
@@ -135,6 +135,8 @@ FOUNDATION_EXPORT const unsigned char EXPERTconnectVersionString[];
 
 + (instancetype)shared;
 
+#pragma mark SDK Functions
+
 /**
  Initializes the Humanify SDK components with the given configuration. Refer to Humanify documentation
  to read what the ECSConfiguration object should be populated with.
@@ -353,8 +355,14 @@ FOUNDATION_EXPORT const unsigned char EXPERTconnectVersionString[];
 /**
  Get details for a skill - such as agent availability, etc.
  */
+- (void) agentAvailabilityWithSkill:(NSString *)skill
+                         completion:(void(^)(NSDictionary *status, NSError *error))completion
+__attribute__((deprecated("On API 5.3 or greater, please use getDetailsForExpertSkill instead.")));
+
 - (void) getDetailsForSkill:(NSString *)skill
-                 completion:(void(^)(NSDictionary *details, NSError *error))completion;
+                 completion:(void(^)(NSDictionary *details, NSError *error))completion
+__attribute__((deprecated("On API 5.3 or greater, please use getDetailsForExpertSkill instead.")));
+
 /**
  Get details for a skill - such as agent availability, etc.
  */

--- a/EXPERTconnect/EXPERTconnect/EXPERTconnect.m
+++ b/EXPERTconnect/EXPERTconnect/EXPERTconnect.m
@@ -663,6 +663,20 @@ NSTimer *breadcrumbTimer;
     return initialViewController;
 }
 
+// Check availability on a singlar skill
+- (void) agentAvailabilityWithSkill:(NSString *)skill
+                         completion:(void(^)(NSDictionary *status, NSError *error))completion
+{
+    ECSURLSessionManager *sessionManager = [[ECSInjector defaultInjector] objectForClass:[ECSURLSessionManager class]];
+    
+    [sessionManager getDetailsForSkill:skill
+                            completion:^(NSDictionary *response, NSError *error)
+     {
+         NSLog(@"Got details for skill: %@", skill);
+         completion( response, error );
+     }];
+}
+
 // Copy getDetailsForSkill from 5.2.x branch
 - (void) getDetailsForSkill:(NSString *)skill
                  completion:(void(^)(NSDictionary *details, NSError *error))completion
@@ -699,7 +713,11 @@ NSTimer *breadcrumbTimer;
     }];
 }
 
-- (void) overrideDeviceLocale:(NSString *)localeString {
+/**
+ Set the header for locale when sending to the Humanify server. Does not override localization strings. 
+ */
+- (void) overrideDeviceLocale:(NSString *)localeString
+{
     self.urlSession.localLocale = localeString;
 }
 

--- a/EXPERTconnect/EXPERTconnectTests/EXPERTconnectTests.m
+++ b/EXPERTconnect/EXPERTconnectTests/EXPERTconnectTests.m
@@ -210,7 +210,8 @@ NSString *_testTenant;
     XCTestExpectation *expectation = [self expectationWithDescription:@"journeyid"];
     
     // Start the first journey
-    [[EXPERTconnect shared] startJourneyWithCompletion:^(NSString *journeyID, NSError *err) {
+    [[EXPERTconnect shared] startJourneyWithCompletion:^(NSString *journeyID, NSError *err)
+    {
         NSLog(@"Test journeyID 1 is %@", journeyID);
         XCTAssert(journeyID.length > 0, @"JourneyID string length was 0.");
         //XCTAssert([journeyID containsString:@"mktwebextc"], @"JourneyID did not contain organization.");
@@ -218,7 +219,8 @@ NSString *_testTenant;
         XCTAssertNotNil([EXPERTconnect shared].journeyID, @"JourneyID was not populated in ExpertConnect object");
         
         // Start a second journey
-        [[EXPERTconnect shared] startJourneyWithCompletion:^(NSString *journeyID2, NSError *err2) {
+        [[EXPERTconnect shared] startJourneyWithCompletion:^(NSString *journeyID2, NSError *err2)
+        {
             NSLog(@"Test journeyID 2 is %@", journeyID2);
             XCTAssert(journeyID2.length > 0, @"JourneyID string length was 0.");
             //XCTAssert([journeyID2 containsString:@"mktwebextc"], @"JourneyID did not contain organization.");
@@ -444,16 +446,22 @@ NSString *_testTenant;
     
     NSString *skillName = @"CE_Mobile_Chat";
     
+    // Should throw a deprecation warning but still work against 5.3 and later (until officially deprecated).
     [[EXPERTconnect shared] getDetailsForSkill:skillName
                                           completion:^(NSDictionary *details, NSError *error)
      {
          NSLog(@"Details: %@", details);
-         
-         XCTAssert(details[@"description"], @"Missing description text.");
-         XCTAssert([details[@"active"] isEqualToString:@"1"] || [details[@"active"] isEqualToString: @"0"], @"Active must be 1 or 0");
-         XCTAssert([details[@"skillName"] containsString:skillName], @"Missing skill name");
-         XCTAssertGreaterThanOrEqual([details[@"estWait"] integerValue], -1, @"Bad estimated wait value");
-         
+         if(error)
+         {
+             XCTFail(@"Error reported: %@", error.description);
+         }
+         else
+         {
+             XCTAssert(details[@"description"], @"Missing description text.");
+             XCTAssert([details[@"active"] isEqualToString:@"1"] || [details[@"active"] isEqualToString: @"0"], @"Active must be 1 or 0");
+             XCTAssert([details[@"skillName"] containsString:skillName], @"Missing skill name");
+             XCTAssertGreaterThanOrEqual([details[@"estWait"] integerValue], -1, @"Bad estimated wait value");
+         }
          [expectation fulfill];
      }];
     

--- a/EXPERTconnectDemo/EXPERTconnectDemo/AppDelegate.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/AppDelegate.m
@@ -182,8 +182,10 @@ static NSString * const ECDFirstRunComplete = @"ECDFirstRunComplete";
 
 - (void)setApplicationDefaults {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSDictionary *appDefaults = [NSDictionary dictionaryWithObject:@"E2C56DB5-DFFB-48D2-B060-D0F5A71096E0"
-                                                            forKey:@"beaconIdentifier"];
+    NSMutableDictionary *appDefaults = [[NSMutableDictionary alloc] init];
+    appDefaults[@"beaconIdentifier"] = @"E2C56DB5-DFFB-48D2-B060-D0F5A71096E0";
+    appDefaults[@"localeOverride"] = Nil;
+    
     [defaults registerDefaults:appDefaults];
     [defaults synchronize];
 }

--- a/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDAdHocChatPicker.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDAdHocChatPicker.m
@@ -67,7 +67,7 @@ int rowToSelect;
 
 -(void)getAgentsAvailableForSkill:(int)index
 {
-    [[EXPERTconnect shared] getDetailsForSkill:[chatSkillsArray objectAtIndex:index]
+    [[EXPERTconnect shared] getDetailsForExpertSkill:[chatSkillsArray objectAtIndex:index]
                                     completion:^(ECSSkillDetail *data, NSError *error)
     {
         if(!error)

--- a/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDAdHocVideoChatPicker.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDAdHocVideoChatPicker.m
@@ -70,7 +70,7 @@ int rowToSelect;
 
 -(void)getAgentsAvailableForSkill:(int)index
 {
-	 [[EXPERTconnect shared] getDetailsForSkill:[chatSkillsArray objectAtIndex:index]
+	 [[EXPERTconnect shared] getDetailsForExpertSkill:[chatSkillsArray objectAtIndex:index]
 									 completion:^(ECSSkillDetail *data, NSError *error)
 	  {
           if(!error)

--- a/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDAdHocViewController.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDAdHocViewController.m
@@ -254,6 +254,8 @@ int chatEstimatedWait,videoChatEstimatedWait,callbackEstimatedWait;
 	 ECSTheme *theme = [[EXPERTconnect shared] theme];
 	 
 	 self.locationManager = [[CLLocationManager alloc] init];
+    
+    [self checkAndUpdateLocaleOverride];
 	 
 	 // In our demo app, we will only use GPS while the app is in the foreground
 	 [self.locationManager requestWhenInUseAuthorization];
@@ -1178,6 +1180,8 @@ int chatEstimatedWait,videoChatEstimatedWait,callbackEstimatedWait;
 {
 	 NSLog(@"Starting an ad-hoc Answer Engine Session");
 	 
+    [self checkAndUpdateLocaleOverride];
+    
 	 NSString *aeContext = [self.selectAdHocAnswerEngineContextPicker currentSelection];
 	 
 	 [self localBreadCrumb:@"Answer Engine started"
@@ -1194,6 +1198,8 @@ int chatEstimatedWait,videoChatEstimatedWait,callbackEstimatedWait;
 {
 	 NSLog(@"Starting an ad-hoc Video Chat Session");
 	 
+    [self checkAndUpdateLocaleOverride];
+    
 	 NSString *chatSkill = [self.selectAdHocVideoChatPicker currentSelection];
 	 
 	 [self localBreadCrumb:@"Video chat started"
@@ -1331,6 +1337,18 @@ int chatEstimatedWait,videoChatEstimatedWait,callbackEstimatedWait;
 	 
 	 ECDLicenseViewController *license = [[ECDLicenseViewController alloc] initWithNibName:nil bundle:nil];
 	 [self.navigationController pushViewController:license animated:YES];
+}
+
+#pragma mark Helper Functions
+
+-(void)checkAndUpdateLocaleOverride
+{
+    // Do a locale override if the settings have been modified.
+    NSString *localeOverride = [[NSUserDefaults standardUserDefaults] objectForKey:@"localeOverride"];
+    if( localeOverride )
+    {
+        [[EXPERTconnect shared] overrideDeviceLocale:localeOverride];
+    }
 }
 
 @end

--- a/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDAdHocVoiceCallbackPicker.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDAdHocVoiceCallbackPicker.m
@@ -70,7 +70,7 @@ int rowToSelect;
 
 -(void)getAgentsAvailableForSkill:(int)index
 {
-	 [[EXPERTconnect shared] getDetailsForSkill:[chatSkillsArray objectAtIndex:index]
+	 [[EXPERTconnect shared] getDetailsForExpertSkill:[chatSkillsArray objectAtIndex:index]
 									 completion:^(ECSSkillDetail *data, NSError *error)
 	  {
           if(!error)

--- a/EXPERTconnectDemo/Settings.bundle/Root.plist
+++ b/EXPERTconnectDemo/Settings.bundle/Root.plist
@@ -5,6 +5,14 @@
 	<key>PreferenceSpecifiers</key>
 	<array>
 		<dict>
+			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>Title</key>
+			<string>Locale Override</string>
+			<key>Key</key>
+			<string>localeOverride</string>
+		</dict>
+		<dict>
 			<key>AutocapitalizationType</key>
 			<string>None</string>
 			<key>AutocorrectionType</key>


### PR DESCRIPTION
This function can be used to override the locale when sending data to
Humanify. This may be used if you want to restrict to a region (such as
USA) for content.
