### PR TITLE
Test Harness Updates

### DIFF
--- a/EXPERTconnectDemo/EXPERTconnectDemo/AppConfig.h
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/AppConfig.h
@@ -14,7 +14,6 @@
 @interface AppConfig : NSObject <ECSAuthenticationTokenDelegate>
 
 @property (nonatomic, strong) NSString *organization;
-@property (nonatomic, strong) NSString *userName; 
 
 + (id)sharedAppConfig;
 - (void) fetchEnvironmentJSON;

--- a/EXPERTconnectDemo/EXPERTconnectDemo/AppConfig.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/AppConfig.m
@@ -11,7 +11,6 @@
 @implementation AppConfig
 
 @synthesize organization;
-@synthesize userName; 
 
 #pragma mark Singleton Methods
 
@@ -134,9 +133,10 @@
 }
 
 -(NSString *)getUserName {
-    //return ([EXPERTconnect shared].userName ? [EXPERTconnect shared].userName : @"Guest");
+    return ([EXPERTconnect shared].userName ? [EXPERTconnect shared].userName : @"Guest");
     //return [EXPERTconnect shared].userName;
-    return self.userName; 
+    //return self.userName;
+    //return (self.userName ? self.userName : @"Guest");
 }
 
 // This function is called by both this app (host app) and the SDK as the official auth token fetch function.
@@ -151,13 +151,6 @@
     NSURL *url = [[NSURL alloc] initWithString:urlString];
     
     NSLog(@"fetchAuthenticationToken - AuthToken URL: %@", url);
-    
-    if(!self.userName || !self.organization)
-    {
-        NSLog(@"Test Harness::fetchAuthenticationToken - Tried to issue API call with missing user or organization.");
-        completion(nil, nil);
-        return;
-    }
     
     [NSURLConnection sendAsynchronousRequest:[[NSURLRequest alloc] initWithURL:url]
                                        queue:[[NSOperationQueue alloc] init]

--- a/EXPERTconnectDemo/EXPERTconnectDemo/AppDelegate.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/AppDelegate.m
@@ -97,9 +97,7 @@ static NSString * const ECDFirstRunComplete = @"ECDFirstRunComplete";
     // Fetch the authToken from our webApp
     [myAppConfig setupAuthenticationDelegate]; // Sets the auth retry delegate
     
-    myAppConfig.userName = [EXPERTconnect shared].userName;
-    
-    if(myAppConfig.organization && myAppConfig.userName)
+    if(myAppConfig.organization && [EXPERTconnect shared].userName)
     {
         [myAppConfig fetchAuthenticationToken:^(NSString *authToken, NSError *error)
          {

--- a/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/Root/ECDMainMenuViewController.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/Root/ECDMainMenuViewController.m
@@ -91,7 +91,7 @@ typedef NS_ENUM(NSInteger, ECDMainMenuRow)
         AppConfig *myAppConfig = [AppConfig sharedAppConfig];
         int initialIndex = 0;
         NSString *url = [[NSUserDefaults standardUserDefaults] objectForKey:@"serverURL"];
-        if(!url || !myAppConfig.organization || !myAppConfig.userName) {
+        if(!url || !myAppConfig.organization || ![EXPERTconnect shared].userName) {
             initialIndex = 3;
         }
         

--- a/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/Root/ECDZoomViewController.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/Root/ECDZoomViewController.m
@@ -193,7 +193,7 @@ static const char *ECDZoomViewControllerKey = "ECDZoomViewControllerKey";
 - (void)showLeftViewController
 {
     AppConfig *appConfig = [AppConfig sharedAppConfig];
-    if(appConfig.userName && appConfig.organization) {
+    if([EXPERTconnect shared].userName && appConfig.organization) {
     
         [UIView animateWithDuration:0.5f delay:0.0f usingSpringWithDamping:0.6f initialSpringVelocity:1.0f options:0 animations:^{
             [self.contentViewController.view endEditing:YES];
@@ -210,7 +210,7 @@ static const char *ECDZoomViewControllerKey = "ECDZoomViewControllerKey";
     else
     {
         NSString *message;
-        if(!appConfig.userName) {
+        if(![EXPERTconnect shared].userName) {
             message = @"Must login with a user to proceed.";
         } else if (!appConfig.organization) {
             message = @"Must select an organiztion/environment to proceed.";

--- a/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDAdHocViewController.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDAdHocViewController.m
@@ -874,7 +874,7 @@ bool _chatActive;
 	 switch (section) {
 		  case SettingsSectionAdHocChat:
 		  {
-              title = @"Ad-Hoc SDK Tests";
+              title = [NSString stringWithFormat:@"User: %@", [EXPERTconnect shared].userName];
 			   //title = ECDLocalizedString(ECDLocalizedStartChatHeader, @"Ad-Hoc SDK Tests");
 			   /*if (chatEstimatedWait>-1 && chatAgentsLoggedOn > -1) {
 					title = [NSString stringWithFormat:@"%@ - %@: %d %@. %@: %d",

--- a/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDLoginViewController.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDLoginViewController.m
@@ -130,8 +130,8 @@
  */
         AppConfig *myAppConfig = [AppConfig sharedAppConfig];
         
-        myAppConfig.userName = weakSelf.emailAddressField.text;
-        //[[EXPERTconnect shared] setUserName:myAppConfig.userName];
+        //myAppConfig.userName = weakSelf.emailAddressField.text;
+        [[EXPERTconnect shared] setUserName:weakSelf.emailAddressField.text];
         
         [myAppConfig fetchAuthenticationToken:^(NSString *authToken, NSError *error)
          {

--- a/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDOrganizationPicker.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDOrganizationPicker.m
@@ -68,7 +68,7 @@ static NSString *const organizationKey = @"organization";
     AppConfig *myAppConfig = [AppConfig sharedAppConfig];
     
     // Start a journey and update org if it is different than what is already there. 
-    if(myAppConfig.userName && (![theOrg isEqualToString:myAppConfig.organization] || !myAppConfig.organization))
+    if([EXPERTconnect shared].userName && (![theOrg isEqualToString:myAppConfig.organization] || !myAppConfig.organization))
     {
         myAppConfig.organization = theOrg;
         [[EXPERTconnect shared] startJourneyWithCompletion:nil];

--- a/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDSettingsViewController.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/ECDSettingsViewController.m
@@ -520,7 +520,8 @@ typedef NS_ENUM(NSInteger, ThemeSectionRows)
           [ECDBugReportEmailer resetLogging];
           [[EXPERTconnect shared] logout];
             AppConfig *myAppConfig = [AppConfig sharedAppConfig];
-            myAppConfig.userName = nil;
+            [EXPERTconnect shared].userName = @"Guest";
+            [[EXPERTconnect shared] setClientID:nil]; // Reset the auth token. 
         }]];
         [self presentViewController:alertController animated:YES completion:nil];
     }


### PR DESCRIPTION
Test Harness will resume the use of the “guest” user for registration.
The username is now displayed at the top of the adhoc page.
