### PR TITLE
PAAS-2223 to master for 6.1.2

### DIFF
--- a/EXPERTconnect/EXPERTconnect/Core/Networking/ECSStompClient.m
+++ b/EXPERTconnect/EXPERTconnect/Core/Networking/ECSStompClient.m
@@ -449,14 +449,16 @@ bool        _isConnecting;
             }
             
         }
+        
+    } else if (frame.command.length == 0 && frame.headers.count == 0) {
+        
+        ECSLogVerbose(self.logger, @"Stomp heart-beat arrived from server.");
+        
     }
-    else if (frame.command.length == 0 && frame.headers.count == 0)
-    {
-        // Pong
-//        ECSLogVerbose(self.logger,@"Stomp PONG arrived from server. Resetting miss count.");
-        _isConnecting = NO;
-        _clientHeartbeatsMissed = 0;
-    }
+    
+    // Any message from server indicates it is "good" reset server heartbeat miss count.
+    _isConnecting = NO;
+    _clientHeartbeatsMissed = 0;
 }
 
 - (void)webSocket:(ECSWebSocket *)webSocket didReceivePong:(NSData *)pongPayload
@@ -648,7 +650,7 @@ bool        _isConnecting;
 
 -(void)doStompHeartbeat:(NSTimer *)timer {
     
-//    ECSLogVerbose(self.logger,@"doStompHeartbeat: beating. Skipped %d beats.", _clientHeartbeatsMissed);
+    ECSLogVerbose(self.logger,@"Timer tick. Missed heartbeat count: %d", _clientHeartbeatsMissed);
     
     if( _clientHeartbeatsMissed >= 3 )
     {

--- a/EXPERTconnect/EXPERTconnect/Info.plist
+++ b/EXPERTconnect/EXPERTconnect/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>179</string>
+	<string>180</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/EXPERTconnectDemo/EXPERTconnectDemo/Info.plist
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>179</string>
+	<string>180</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
The server only sends a heartbeat after 20 seconds of no traffic (if
the heartbeat setting is 20000, which the SDK always sets it to.
If the user or agent constantly chat, never letting 20 seconds of idle
occur, no heartbeat will ever be sent from the server.
Currently, the iOS SDK is only checking for heartbeats to determine if
server is alive.
The fix is that ANY chat message should reset the heartbeatMiss counter.