### PR TITLE
Fix for paas-2520.

### DIFF
--- a/EXPERTconnect/EXPERTconnect.xcodeproj/project.pbxproj
+++ b/EXPERTconnect/EXPERTconnect.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		030AF2131AF7E20C0056BFB0 /* ECSChatAddChannelMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 030AF2111AF7E20C0056BFB0 /* ECSChatAddChannelMessage.m */; };
 		030AF2161AF807E30056BFB0 /* ECSChatHistoryMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 030AF2141AF807E30056BFB0 /* ECSChatHistoryMessage.h */; };
 		030AF2171AF807E30056BFB0 /* ECSChatHistoryMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 030AF2151AF807E30056BFB0 /* ECSChatHistoryMessage.m */; };
-		030AF21A1AF8080A0056BFB0 /* ECSChatHistoryResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 030AF2181AF8080A0056BFB0 /* ECSChatHistoryResponse.h */; };
+		030AF21A1AF8080A0056BFB0 /* ECSChatHistoryResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 030AF2181AF8080A0056BFB0 /* ECSChatHistoryResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		030AF21B1AF8080A0056BFB0 /* ECSChatHistoryResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 030AF2191AF8080A0056BFB0 /* ECSChatHistoryResponse.m */; };
 		030AF2571AF91FAF0056BFB0 /* ECSChatNotificationMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 030AF2551AF91FAE0056BFB0 /* ECSChatNotificationMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		030AF2581AF91FAF0056BFB0 /* ECSChatNotificationMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 030AF2561AF91FAE0056BFB0 /* ECSChatNotificationMessage.m */; };
@@ -1745,6 +1745,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				030AF21A1AF8080A0056BFB0 /* ECSChatHistoryResponse.h in Headers */,
 				C47ADC3E1F448B2500B85AB9 /* ZSWTappableLabel.h in Headers */,
 				C47ADBB81F39276D00B85AB9 /* ECSMessageTask.h in Headers */,
 				C4BE82011F38BBA800ED290B /* SessionTaskQueue.h in Headers */,
@@ -1913,7 +1914,6 @@
 				03A64D321B01042000AED79D /* ECSEndChatSurveyView.h in Headers */,
 				03BE27521ADC1BD60099F2EB /* ECSChatNetworkActionCell.h in Headers */,
 				D86BC4C21B8E3199005B9629 /* ECSVideoChatActionType.h in Headers */,
-				030AF21A1AF8080A0056BFB0 /* ECSChatHistoryResponse.h in Headers */,
 				03F0BD4B1A7130CA00E90E7F /* UIViewController+ECSNibLoading.h in Headers */,
 				C6F6FF0A1B8464CB00C40E97 /* ECSWorkflow.h in Headers */,
 				D83F78BB1B7D2D0B00F307D4 /* ReachabilityManager.h in Headers */,
@@ -1982,7 +1982,6 @@
 				TargetAttributes = {
 					03978EE11A602AEF007793D6 = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = 4F2XQ7R275;
 					};
 					03978EEC1A602AEF007793D6 = {
 						CreatedOnToolsVersion = 6.1.1;
@@ -2526,6 +2525,7 @@
 				CURRENT_PROJECT_VERSION = 1.0.0;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1.0.0;
 				DYLIB_CURRENT_VERSION = 1.0.0;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/EXPERTconnect/EXPERTconnect/Core/Networking/ECSStompChatClient.h
+++ b/EXPERTconnect/EXPERTconnect/Core/Networking/ECSStompChatClient.h
@@ -12,6 +12,7 @@
 #import "ECSChannelStateMessage.h"
 #import "ECSChatVoiceAuthenticationMessage.h"
 #import "ECSStompClient.h"
+#import "ECSChatHistoryResponse.h"
 
 @class ECSActionType;
 @class ECSChatActionType; 

--- a/EXPERTconnect/EXPERTconnect/EXPERTconnect.h
+++ b/EXPERTconnect/EXPERTconnect/EXPERTconnect.h
@@ -448,6 +448,9 @@ __attribute__((deprecated("See documentation on the Identity Delegate authentica
 
 -(void)setHost:(NSString *)theHost;
 
+
+- (void) getTranscriptForConversation:(NSString *)conversationID withCompletion:(void(^)(NSArray *messages, NSError *error))completion;
+
 #pragma mark Breadcrumb Functions
 
 /**

--- a/EXPERTconnect/EXPERTconnect/EXPERTconnect.m
+++ b/EXPERTconnect/EXPERTconnect/EXPERTconnect.m
@@ -916,6 +916,56 @@ NSTimer *breadcrumbTimer;
     return initialViewController;
 }
 
+- (void) getTranscriptForConversation:(NSString *)conversationID withCompletion:(void(^)(NSArray *messages, NSError *error))completion {
+    
+    ECSURLSessionManager *urlSession = [[ECSInjector defaultInjector] objectForClass:[ECSURLSessionManager class]];
+    
+    [urlSession getChatHistoryDetailsForJourneyId:urlSession.journeyID withCompletion:^(ECSChatHistoryResponse *response, NSError *error)
+    {
+         if( ! error ) {
+             
+             NSArray *data = [response chatMessages];
+             
+             NSMutableArray *filteredData;
+             
+             if( data && data.count > 0 ) {
+                 
+                 if( conversationID ) {
+                     
+                     filteredData = [[NSMutableArray alloc] initWithCapacity:data.count];
+                     
+                     for (ECSChatMessage *message in data) {
+                         
+                         if( [message.conversationId isEqualToString:conversationID] ) {
+                             
+                             [filteredData addObject:message];
+                             
+                         }
+                     }
+                     
+                 } else {
+                     
+                     filteredData = [[NSMutableArray alloc] initWithArray:data];
+                     
+                 }
+                 
+                 completion(filteredData, nil);
+                 
+             } else {
+                 // Empty array. Return nil.
+                 completion(nil, nil);
+             }
+             
+         } else {
+             
+             completion(nil, error);
+             
+         }
+         
+    }];
+    
+}
+
 #pragma mark Breadcrumb Functions
 
 /**

--- a/EXPERTconnect/EXPERTconnect/Info.plist
+++ b/EXPERTconnect/EXPERTconnect/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>220</string>
+	<string>221</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSCafeXMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSCafeXMessage.h
@@ -12,7 +12,7 @@
 
 @interface ECSCafeXMessage : ECSChatMessage <ECSAddressableChatMessage>
 
-@property (strong, nonatomic) NSString *conversationId;
+//@property (strong, nonatomic) NSString *conversationId;
 @property (strong, nonatomic) NSString *channelId;
 @property (strong, nonatomic) NSString *messageId;
 @property (strong, nonatomic) NSString *from;

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChannelStateMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChannelStateMessage.h
@@ -45,7 +45,7 @@ typedef NS_ENUM(NSInteger, ECSTerminatedBy)
 
 @interface ECSChannelStateMessage : ECSChatMessage
 
-@property (strong, nonatomic) NSString *conversationId;
+//@property (strong, nonatomic) NSString *conversationId;
 @property (strong, nonatomic) NSString *channelId;
 @property (strong, nonatomic) NSString *state;
 @property (strong, nonatomic) NSNumber *estimatedWait;

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChannelTimeoutWarningMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChannelTimeoutWarningMessage.h
@@ -17,7 +17,7 @@
  */
 @interface ECSChannelTimeoutWarningMessage : ECSChatMessage <ECSAddressableChatMessage>
 
-@property (strong, nonatomic) NSString *conversationId;
+//@property (strong, nonatomic) NSString *conversationId;
 @property (strong, nonatomic) NSString *channelId;
 @property (strong, nonatomic) NSNumber *version;
 @property (strong, nonatomic) NSString *timeoutSeconds;

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatAddChannelMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatAddChannelMessage.h
@@ -11,7 +11,7 @@
 
 @interface ECSChatAddChannelMessage : ECSChatMessage <ECSAddressableChatMessage>
 
-@property (strong, nonatomic) NSString *conversationId;
+//@property (strong, nonatomic) NSString *conversationId;
 @property (strong, nonatomic) NSString *channelId;
 @property (strong, nonatomic) NSString *from;
 @property (strong, nonatomic) NSString *mediaType;

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatAssociateInfoMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatAssociateInfoMessage.h
@@ -11,7 +11,7 @@
 
 @interface ECSChatAssociateInfoMessage : ECSChatMessage <ECSAddressableChatMessage>
 
-@property (strong, nonatomic) NSString *conversationId;
+//@property (strong, nonatomic) NSString *conversationId;
 @property (strong, nonatomic) NSString *channelId;
 @property (strong, nonatomic) NSString *messageId;
 @property (strong, nonatomic) NSString *from;

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatCoBrowseMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatCoBrowseMessage.h
@@ -11,7 +11,7 @@
 
 @interface ECSChatCoBrowseMessage : ECSChatMessage <ECSAddressableChatMessage>
 
-@property (strong, nonatomic) NSString *conversationId;
+//@property (strong, nonatomic) NSString *conversationId;
 @property (strong, nonatomic) NSString *channelId;
 @property (strong, nonatomic) NSString *messageId;
 @property (strong, nonatomic) NSString *from;

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatFormMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatFormMessage.h
@@ -14,7 +14,7 @@
 
 @interface ECSChatFormMessage : ECSChatMessage <ECSAddressableChatMessage>
 
-@property (strong, nonatomic) NSString *conversationId;
+//@property (strong, nonatomic) NSString *conversationId;
 @property (strong, nonatomic) NSString *channelId;
 @property (strong, nonatomic) NSString *from;
 @property (strong, nonatomic) NSString *formName;

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatMediaMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatMediaMessage.h
@@ -16,7 +16,7 @@ typedef NS_ENUM(NSUInteger, ECSChatMediaType)
 };
 @interface ECSChatMediaMessage : ECSChatMessage <ECSAddressableChatMessage>
 
-@property (strong, nonatomic) NSString *conversationId;
+//@property (strong, nonatomic) NSString *conversationId;
 @property (strong, nonatomic) NSString *channelId;
 @property (strong, nonatomic) NSString *from;
 @property (strong, nonatomic) NSString *url;

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatMessage.h
@@ -15,5 +15,6 @@
 @interface ECSChatMessage : ECSJSONObject <NSCopying, ECSJSONSerializing>
 
 @property (assign, nonatomic) BOOL fromAgent;
+@property (strong, nonatomic) NSString *conversationId;
 
 @end

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatMessage.m
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatMessage.m
@@ -18,7 +18,8 @@
 {
     ECSChatMessage *message = [[self class] new];
     message.fromAgent = self.fromAgent;
-
+    message.conversationId = self.conversationId;
+    
     return message;
 }
 

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatNotificationMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatNotificationMessage.h
@@ -14,7 +14,7 @@
 
 @interface ECSChatNotificationMessage : ECSChatMessage <ECSJSONSerializing, ECSAddressableChatMessage>
 
-@property (strong, nonatomic) NSString *conversationId;
+//@property (strong, nonatomic) NSString *conversationId;
 @property (strong, nonatomic) NSString *channelId;
 @property (strong, nonatomic) NSString *from;
 @property (strong, nonatomic) NSString *type;

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatStateMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatStateMessage.h
@@ -24,7 +24,7 @@ typedef NS_ENUM(NSUInteger, ECSChatState)
  */
 @interface ECSChatStateMessage : ECSChatMessage <ECSAddressableChatMessage>
 
-@property (strong, nonatomic) NSString *conversationId;
+//@property (strong, nonatomic) NSString *conversationId;
 @property (strong, nonatomic) NSString *channelId;
 @property (strong, nonatomic) NSString *from;
 @property (strong, nonatomic) NSString *to;

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatTextMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatTextMessage.h
@@ -14,7 +14,7 @@
 
 @interface ECSChatTextMessage : ECSChatMessage <ECSAddressableChatMessage>
 
-@property (strong, nonatomic) NSString *conversationId;
+//@property (strong, nonatomic) NSString *conversationId;
 @property (strong, nonatomic) NSString *channelId;
 @property (strong, nonatomic) NSString *messageId;
 @property (strong, nonatomic) NSString *from;

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatURLMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatURLMessage.h
@@ -11,7 +11,7 @@
 
 @interface ECSChatURLMessage : ECSChatMessage <ECSAddressableChatMessage>
 
-@property (strong, nonatomic) NSString *conversationId;
+//@property (strong, nonatomic) NSString *conversationId;
 @property (strong, nonatomic) NSString *channelId;
 @property (strong, nonatomic) NSString *from;
 @property (strong, nonatomic) NSString *url;

--- a/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatVoiceAuthenticationMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/Chat/ECSChatVoiceAuthenticationMessage.h
@@ -11,7 +11,7 @@
 
 @interface ECSChatVoiceAuthenticationMessage : ECSChatMessage <ECSAddressableChatMessage>
 
-@property (strong, nonatomic) NSString *conversationId;
+//@property (strong, nonatomic) NSString *conversationId;
 @property (strong, nonatomic) NSString *channelId;
 @property (strong, nonatomic) NSString *messageId;
 @property (strong, nonatomic) NSString *from;

--- a/EXPERTconnect/EXPERTconnect/Models/ECSSendQuestionMessage.h
+++ b/EXPERTconnect/EXPERTconnect/Models/ECSSendQuestionMessage.h
@@ -18,7 +18,7 @@
 @property (strong, nonatomic) NSString *questionText;
 @property (strong, nonatomic) NSString *channelId;
 @property (strong, nonatomic) NSString *version;
-@property (strong, nonatomic) NSString *conversationId;
+//@property (strong, nonatomic) NSString *conversationId;
 @property (strong, nonatomic) NSString *interfaceName;
 @property (strong, nonatomic) NSString *from;
 

--- a/EXPERTconnect/EXPERTconnect/UI/Sections/Forms/ECSFormViewController.m
+++ b/EXPERTconnect/EXPERTconnect/UI/Sections/Forms/ECSFormViewController.m
@@ -363,7 +363,7 @@
     
     [UIView animateWithDuration:[number doubleValue]
                      animations:^{
-                         CGRect keyboardFrame = [[info objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
+                         //CGRect keyboardFrame = [[info objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
 //                         self.buttonViewBottomConstraint.constant = keyboardFrame.size.height;
                          [self.view layoutIfNeeded];
                      }];

--- a/EXPERTconnectDemo/EXPERTconnectDemo/Info.plist
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>220</string>
+	<string>221</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/Proof_of_Concept/ECDSimpleChatViewController.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/Proof_of_Concept/ECDSimpleChatViewController.m
@@ -126,8 +126,11 @@ CGPoint     _originalCenter;
 }
 
 - (void)backButtonPressed:(id)sender {
+    
     [self.chatClient disconnect];
+    
     [self.navigationController popViewControllerAnimated:YES];
+    
 }
 
 #pragma mark - ECSStompChatClient delegate callbacks

--- a/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/Configuration Views/ECDChatConfigVC.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/Configuration Views/ECDChatConfigVC.m
@@ -89,7 +89,7 @@ static NSString *const lastChatSkillKey = @"lastSkillSelected";
 }
 
 - (void)viewWillAppear:(BOOL)animated {
-    [self setupPickerView];
+    [self setupPickerView];    
 }
 
 - (void)didReceiveMemoryWarning {
@@ -285,15 +285,10 @@ static NSString *const lastChatSkillKey = @"lastSkillSelected";
     
     ECSURLSessionManager *sessionManager = [[EXPERTconnect shared] urlSession];
     
-    // Test 1: Get Chat history (record of chat starts for this user)
-    [sessionManager getChatHistoryDetailsForJourneyId:sessionManager.journeyID withCompletion:^(ECSChatHistoryResponse *response, NSError *error) {
-        NSLog(@"Details: %@", response);
-        
-    }];
+   
+    ECDChatHistoryVC *historyVC = [[ECDChatHistoryVC alloc] init];
     
-    //ECDChatHistoryVC *historyVC = [[ECDChatHistoryVC alloc] init];
-    
-    //[self.navigationController pushViewController:historyVC animated:YES];
+    [self.navigationController pushViewController:historyVC animated:YES];
     
 }
 

--- a/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/Configuration Views/ECDChatHistoryVC.h
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/Configuration Views/ECDChatHistoryVC.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 #import <EXPERTconnect/EXPERTconnect.h>
 
-@interface ECDChatHistoryVC : UIViewController
+@interface ECDChatHistoryVC : UIViewController 
 
 @property (weak, nonatomic) IBOutlet UITextView *historyTextView;
 

--- a/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/Configuration Views/ECDChatHistoryVC.m
+++ b/EXPERTconnectDemo/EXPERTconnectDemo/ViewControllers/User/Configuration Views/ECDChatHistoryVC.m
@@ -12,11 +12,43 @@
 
 @end
 
-@implementation ECDChatHistoryVC
+@implementation ECDChatHistoryVC 
+
+NSArray *historyMessages;
 
 - (void)viewDidLoad {
     [super viewDidLoad];
     // Do any additional setup after loading the view from its nib.
+    
+    self.historyTextView.text = @"Loading history data...";
+    
+    NSString *conversationID = [EXPERTconnect shared].urlSession.conversation.conversationID;
+
+    [[EXPERTconnect shared] getTranscriptForConversation:conversationID withCompletion:^(NSArray *messages, NSError *error) {
+        
+        if( ! error ) {
+            
+            if( messages ) {
+                
+                // Happy path. We have history. Show it.
+                historyMessages = messages;
+                self.historyTextView.text = historyMessages.description;
+                
+            } else {
+                
+                // No history found.
+                self.historyTextView.text = [NSString stringWithFormat:@"No chat history found for conversationID: %@ on journey: %@", conversationID, [EXPERTconnect shared].journeyID];
+                
+            }
+            
+        } else {
+            
+            // An error retrieving history. 
+            self.historyTextView.text = [NSString stringWithFormat:@"Error loading history: %@", error];
+            
+        }
+        
+    }];
     
 }
 


### PR DESCRIPTION
Also includes moving “conversationID” to the superclass
(ECSChatMessage) from each individual message object.